### PR TITLE
Allows auto-resizing of the posframe.

### DIFF
--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -68,6 +68,11 @@ When 0, no border is showed."
   :group 'transient-posframe
   :type 'string)
 
+(defcustom transient-posframe-refresh 10
+  "Interval to automatically resize the posframe."
+  :group 'transient-posframe
+  :type 'number)
+
 (defface transient-posframe
   '((t (:inherit default)))
   "Face used by the transient-posframe."
@@ -95,7 +100,8 @@ When 0, no border is showed."
 			   :min-height transient-posframe-min-height
 			   :internal-border-width transient-posframe-border-width
 			   :internal-border-color (face-attribute 'transient-posframe-border :background nil t)
-			   :override-parameters transient-posframe-parameters)))
+			   :override-parameters transient-posframe-parameters
+			   :refresh transient-posframe-refresh)))
       (frame-selected-window posframe))))
 
 (defun transient-posframe--delete ()


### PR DESCRIPTION
This uses the "refresh" property when creating a posframe. I set it to a large number yet it still can resize the transient posframe quite well. 

Please let me know if there are any concerns with this. Thanks!