### PR TITLE
chg: specifying :width and :height

### DIFF
--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -91,6 +91,8 @@ When 0, no border is showed."
 			   :poshandler transient-posframe-poshandler
 			   :background-color (face-attribute 'transient-posframe :background nil t)
 			   :foreground-color (face-attribute 'transient-posframe :foreground nil t)
+			   :width (round (* (frame-width) 0.62))
+			   :height (with-current-buffer buffer (1- (count-screen-lines (point-min) (point-max))))
 			   :min-width transient-posframe-min-width
 			   :min-height transient-posframe-min-height
 			   :internal-border-width transient-posframe-border-width


### PR DESCRIPTION
fixes https://github.com/yanghaoxie/transient-posframe/issues/5 and a similar issue with width

(`:height` line copied from https://github.com/yanghaoxie/transient-posframe/issues/5#issuecomment-1974871665 and `:width` line copied from https://github.com/tumashu/vertico-posframe/blob/main/vertico-posframe.el)