### PR TITLE
Fix setting and updating size of transient's frame

### DIFF
--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -48,14 +48,14 @@ When nil, Using current frame's font as fallback."
   :type 'function)
 
 (defcustom transient-posframe-min-width 80
-  "The width of transient-min-posframe."
+  "The minimal width of transient-posframe."
   :group 'transient-posframe
-  :type 'number)
+  :type '(choice number (const :tag "No minimum" nil)))
 
 (defcustom transient-posframe-min-height 30
-  "The height of transient-min-posframe."
+  "The minimal height of transient-posframe."
   :group 'transient-posframe
-  :type 'number)
+  :type '(choice number (const :tag "No minimum" nil)))
 
 (defcustom transient-posframe-border-width 1
   "The border width used by transient-posframe.

--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -121,6 +121,7 @@ When 0, no border is showed."
 
 ;; Local Variables:
 ;; coding: utf-8-unix
+;; indent-tabs-mode: t
 ;; End:
 
 ;;; transient-posframe.el ends here

--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -109,13 +109,19 @@ When 0, no border is showed."
   :group 'transient-posframe
   :global t
   :lighter nil
-  (if transient-posframe-mode
-      (progn
-	(setq transient-posframe-display-buffer-action--previous transient-display-buffer-action
-	      transient-display-buffer-action '(transient-posframe--show-buffer))
-	(advice-add 'transient--delete-window :override #'transient-posframe--delete))
-    (setq transient-display-buffer-action transient-posframe-display-buffer-action--previous)
-    (advice-remove 'transient--delete-window #'transient-posframe--delete)))
+  (cond
+   (transient-posframe-mode
+    (setq transient-posframe-display-buffer-action--previous
+	  transient-display-buffer-action)
+    (setq transient-display-buffer-action
+	  '(transient-posframe--show-buffer))
+    (advice-add 'transient--delete-window :override
+		#'transient-posframe--delete))
+   (t
+    (setq transient-display-buffer-action
+	  transient-posframe-display-buffer-action--previous)
+    (advice-remove 'transient--delete-window
+		   #'transient-posframe--delete))))
 
 (provide 'transient-posframe)
 

--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -108,7 +108,7 @@ When 0, no border is showed."
 (provide 'transient-posframe)
 
 ;; Local Variables:
-;; coding: utf-8-unix
+;; coding: utf-8
 ;; indent-tabs-mode: t
 ;; End:
 

--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -38,9 +38,9 @@
 
 (defcustom transient-posframe-font nil
   "The font used by transient-posframe.
-When nil, Using current frame's font as fallback."
+When nil, use current frame's font as fallback."
   :group 'transient-posframe
-  :type 'string)
+  :type '(choice string (const :tag "Use font of current frame")))
 
 (defcustom transient-posframe-poshandler #'posframe-poshandler-frame-center
   "The poshandler of transient-posframe."
@@ -66,7 +66,7 @@ When 0, no border is showed."
 (defcustom transient-posframe-parameters nil
   "The frame parameters used by transient-posframe."
   :group 'transient-posframe
-  :type 'string)
+  :type '(alist :key-type symbol :value-type sexp))
 
 (defface transient-posframe
   '((t (:inherit default)))

--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/yanghaoxie/transient-posframe
 ;; Version: 0.1.0
 ;; Keywords: convenience, bindings, tooltip
-;; Package-Requires: ((emacs "26.0")(posframe "0.4.3")(transient "0.2.0"))
+;; Package-Requires: ((emacs "26.0")(posframe "1.4.4")(transient "0.7.9"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -84,20 +84,20 @@ When 0, no border is showed."
 (defun transient-posframe--show-buffer (buffer _alist)
   "Show BUFFER in posframe and we do not use _ALIST at this period."
   (when (posframe-workable-p)
-    (let* ((posframe
-	    (posframe-show buffer
-			   :font transient-posframe-font
-			   :position (point)
-			   :poshandler transient-posframe-poshandler
-			   :background-color (face-attribute 'transient-posframe :background nil t)
-			   :foreground-color (face-attribute 'transient-posframe :foreground nil t)
-			   :initialize #'transient-posframe--initialize
-			   :min-width transient-posframe-min-width
-			   :min-height transient-posframe-min-height
-			   :internal-border-width transient-posframe-border-width
-			   :internal-border-color (face-attribute 'transient-posframe-border :background nil t)
-			   :override-parameters transient-posframe-parameters)))
-      (frame-selected-window posframe))))
+    (posframe-show
+     buffer
+     :font transient-posframe-font
+     :position (point)
+     :poshandler transient-posframe-poshandler
+     :background-color (face-attribute 'transient-posframe :background nil t)
+     :foreground-color (face-attribute 'transient-posframe :foreground nil t)
+     :initialize #'transient-posframe--initialize
+     :min-width transient-posframe-min-width
+     :min-height transient-posframe-min-height
+     :internal-border-width transient-posframe-border-width
+     :internal-border-color (face-attribute 'transient-posframe-border
+					    :background nil t)
+     :override-parameters transient-posframe-parameters)))
 
 (defun transient-posframe--initialize ()
   "Initialize transient posframe."

--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -91,12 +91,24 @@ When 0, no border is showed."
 			   :poshandler transient-posframe-poshandler
 			   :background-color (face-attribute 'transient-posframe :background nil t)
 			   :foreground-color (face-attribute 'transient-posframe :foreground nil t)
+			   :initialize #'transient-posframe--initialize
 			   :min-width transient-posframe-min-width
 			   :min-height transient-posframe-min-height
 			   :internal-border-width transient-posframe-border-width
 			   :internal-border-color (face-attribute 'transient-posframe-border :background nil t)
 			   :override-parameters transient-posframe-parameters)))
       (frame-selected-window posframe))))
+
+(defun transient-posframe--initialize ()
+  "Initialize transient posframe."
+  (setq window-resize-pixelwise t)
+  (setq window-size-fixed nil))
+
+(defun transient-posframe--resize (window)
+  "Resize transient posframe."
+  (fit-frame-to-buffer-1 (window-frame window)
+                         nil transient-posframe-min-height
+                         nil transient-posframe-min-width))
 
 (defun transient-posframe--delete ()
   "Delete transient posframe."
@@ -116,12 +128,16 @@ When 0, no border is showed."
     (setq transient-display-buffer-action
 	  '(transient-posframe--show-buffer))
     (advice-add 'transient--delete-window :override
-		#'transient-posframe--delete))
+		#'transient-posframe--delete)
+    (advice-add 'transient--fit-window-to-buffer :override
+		#'transient-posframe--resize))
    (t
     (setq transient-display-buffer-action
 	  transient-posframe-display-buffer-action--previous)
     (advice-remove 'transient--delete-window
-		   #'transient-posframe--delete))))
+		   #'transient-posframe--delete)
+    (advice-remove 'transient--fit-window-to-buffer
+		   #'transient-posframe--resize))))
 
 (provide 'transient-posframe)
 

--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -47,7 +47,7 @@ When nil, Using current frame's font as fallback."
   :group 'transient-posframe
   :type 'function)
 
-(defcustom transient-posframe-min-width 80
+(defcustom transient-posframe-min-width 83
   "The minimal width of transient-posframe."
   :group 'transient-posframe
   :type '(choice number (const :tag "No minimum" nil)))

--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -85,7 +85,7 @@ When 0, no border is showed."
    :min-width transient-minimal-frame-width
    :internal-border-width transient-posframe-border-width
    :internal-border-color (face-attribute 'transient-posframe-border
-					  :background nil t)
+                                          :background nil t)
    :override-parameters transient-posframe-parameters)
   (get-buffer-window transient--buffer-name t))
 
@@ -98,18 +98,18 @@ When 0, no border is showed."
   (cond
    (transient-posframe-mode
     (setq transient-posframe-display-buffer-action--previous
-	  transient-display-buffer-action)
+          transient-display-buffer-action)
     (setq transient-display-buffer-action
-	  '(transient-posframe--show-buffer)))
+          '(transient-posframe--show-buffer)))
    (t
     (setq transient-display-buffer-action
-	  transient-posframe-display-buffer-action--previous))))
+          transient-posframe-display-buffer-action--previous))))
 
 (provide 'transient-posframe)
 
 ;; Local Variables:
 ;; coding: utf-8
-;; indent-tabs-mode: t
+;; indent-tabs-mode: nil
 ;; End:
 
 ;;; transient-posframe.el ends here

--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -73,20 +73,21 @@ When 0, no border is showed."
 
 (defun transient-posframe--show-buffer (buffer _alist)
   "Show BUFFER in posframe and we do not use _ALIST at this period."
-  (when (posframe-workable-p)
-    (posframe-show
-     buffer
-     :font transient-posframe-font
-     :position (point)
-     :poshandler transient-posframe-poshandler
-     :background-color (face-attribute 'transient-posframe :background nil t)
-     :foreground-color (face-attribute 'transient-posframe :foreground nil t)
-     :min-width transient-minimal-frame-width
-     :internal-border-width transient-posframe-border-width
-     :internal-border-color (face-attribute 'transient-posframe-border
-					    :background nil t)
-     :override-parameters transient-posframe-parameters)
-    (get-buffer-window transient--buffer-name t)))
+  (unless (posframe-workable-p)
+    (error "Posframe is not workable"))
+  (posframe-show
+   buffer
+   :font transient-posframe-font
+   :position (point)
+   :poshandler transient-posframe-poshandler
+   :background-color (face-attribute 'transient-posframe :background nil t)
+   :foreground-color (face-attribute 'transient-posframe :foreground nil t)
+   :min-width transient-minimal-frame-width
+   :internal-border-width transient-posframe-border-width
+   :internal-border-color (face-attribute 'transient-posframe-border
+					  :background nil t)
+   :override-parameters transient-posframe-parameters)
+  (get-buffer-window transient--buffer-name t))
 
 ;;;###autoload
 (define-minor-mode transient-posframe-mode

--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -97,7 +97,8 @@ When 0, no border is showed."
      :internal-border-width transient-posframe-border-width
      :internal-border-color (face-attribute 'transient-posframe-border
 					    :background nil t)
-     :override-parameters transient-posframe-parameters)))
+     :override-parameters transient-posframe-parameters)
+    (get-buffer-window transient--buffer-name t)))
 
 (defun transient-posframe--initialize ()
   "Initialize transient posframe."

--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/yanghaoxie/transient-posframe
 ;; Version: 0.1.0
 ;; Keywords: convenience, bindings, tooltip
-;; Package-Requires: ((emacs "26.0")(posframe "1.4.4")(transient "0.7.9"))
+;; Package-Requires: ((emacs "26.1") (posframe "1.4.4") (transient "0.8.2"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -47,16 +47,6 @@ When nil, use current frame's font as fallback."
   :group 'transient-posframe
   :type 'function)
 
-(defcustom transient-posframe-min-width 83
-  "The minimal width of transient-posframe."
-  :group 'transient-posframe
-  :type '(choice number (const :tag "No minimum" nil)))
-
-(defcustom transient-posframe-min-height nil
-  "The minimal height of transient-posframe."
-  :group 'transient-posframe
-  :type '(choice number (const :tag "No minimum" nil)))
-
 (defcustom transient-posframe-border-width 1
   "The border width used by transient-posframe.
 When 0, no border is showed."
@@ -91,30 +81,12 @@ When 0, no border is showed."
      :poshandler transient-posframe-poshandler
      :background-color (face-attribute 'transient-posframe :background nil t)
      :foreground-color (face-attribute 'transient-posframe :foreground nil t)
-     :initialize #'transient-posframe--initialize
-     :min-width transient-posframe-min-width
-     :min-height transient-posframe-min-height
+     :min-width transient-minimal-frame-width
      :internal-border-width transient-posframe-border-width
      :internal-border-color (face-attribute 'transient-posframe-border
 					    :background nil t)
      :override-parameters transient-posframe-parameters)
     (get-buffer-window transient--buffer-name t)))
-
-(defun transient-posframe--initialize ()
-  "Initialize transient posframe."
-  (setq window-resize-pixelwise t)
-  (setq window-size-fixed nil))
-
-(defun transient-posframe--resize (window)
-  "Resize transient posframe."
-  (fit-frame-to-buffer-1 (window-frame window)
-                         nil transient-posframe-min-height
-                         nil transient-posframe-min-width))
-
-(defun transient-posframe--delete ()
-  "Delete transient posframe."
-  (posframe-delete-frame transient--buffer-name)
-  (posframe--kill-buffer transient--buffer-name))
 
 ;;;###autoload
 (define-minor-mode transient-posframe-mode
@@ -127,18 +99,10 @@ When 0, no border is showed."
     (setq transient-posframe-display-buffer-action--previous
 	  transient-display-buffer-action)
     (setq transient-display-buffer-action
-	  '(transient-posframe--show-buffer))
-    (advice-add 'transient--delete-window :override
-		#'transient-posframe--delete)
-    (advice-add 'transient--fit-window-to-buffer :override
-		#'transient-posframe--resize))
+	  '(transient-posframe--show-buffer)))
    (t
     (setq transient-display-buffer-action
-	  transient-posframe-display-buffer-action--previous)
-    (advice-remove 'transient--delete-window
-		   #'transient-posframe--delete)
-    (advice-remove 'transient--fit-window-to-buffer
-		   #'transient-posframe--resize))))
+	  transient-posframe-display-buffer-action--previous))))
 
 (provide 'transient-posframe)
 

--- a/transient-posframe.el
+++ b/transient-posframe.el
@@ -52,7 +52,7 @@ When nil, Using current frame's font as fallback."
   :group 'transient-posframe
   :type '(choice number (const :tag "No minimum" nil)))
 
-(defcustom transient-posframe-min-height 30
+(defcustom transient-posframe-min-height nil
   "The minimal height of transient-posframe."
   :group 'transient-posframe
   :type '(choice number (const :tag "No minimum" nil)))


### PR DESCRIPTION
This fixes the regression described in #5.  Additionally fixes a second issue, which (I assume) has always existed.  Please see 4db747a8d1a332c3b634cf4c302c14c9c96bf01f for details.

#6 also tries to fix the regression, but it just hacks around it without understanding the cause.

I've also included some cleanup and minor improvements.  Feel free to drop the parts you don't like.